### PR TITLE
Add regular expression to sanitize user input

### DIFF
--- a/typo_w-direction.php
+++ b/typo_w-direction.php
@@ -8,7 +8,7 @@
 	if(!(empty($_GET["rec_count"]))) { $rec_count = $_GET["rec_count"]; } else { $rec_count = 10; }
 	if(!(empty($_GET["avg_hours"]))) { $avg_hours = $_GET["avg_hours"]; } else { $avg_hours = 1; }
 
-	if(!(empty($_GET["sdate"]))) { $sdate = $_GET["sdate"]; } else { $sdate = date("Y-m-d"); }
+	if(!(empty($_GET["sdate"])) && preg_match("/^\d{4}-(0\d|1[0-2])-(0\d|1\d|2\d|3[01])$/s", $_GET["sdate"])) { $sdate = $_GET["sdate"]; } else { $sdate = date("Y-m-d"); }
 
 
  function last_records($rcount, $connection) {

--- a/typo_w-press.php
+++ b/typo_w-press.php
@@ -8,7 +8,7 @@ date_default_timezone_set("Europe/Berlin");
 	if(!(empty($_GET["rec_count"]))) { $rec_count = $_GET["rec_count"]; } else { $rec_count = 10; }
 	if(!(empty($_GET["avg_hours"]))) { $avg_hours = $_GET["avg_hours"]; } else { $avg_hours = 1; }
 
-	if(!(empty($_GET["sdate"]))) { $sdate = $_GET["sdate"]; } else { $sdate = date("Y-m-d"); }
+	if(!(empty($_GET["sdate"])) && preg_match("/^\d{4}-(0\d|1[0-2])-(0\d|1\d|2\d|3[01])$/s", $_GET["sdate"])) { $sdate = $_GET["sdate"]; } else { $sdate = date("Y-m-d"); }
 
 
 

--- a/typo_w-speed.php
+++ b/typo_w-speed.php
@@ -15,7 +15,7 @@ date_default_timezone_set("Europe/Berlin");
 	if(!(empty($_GET["rec_count"]))) { $rec_count = $_GET["rec_count"]; } else { $rec_count = 10; }
 	if(!(empty($_GET["avg_hours"]))) { $avg_hours = $_GET["avg_hours"]; } else { $avg_hours = 1; }
 
-	if(!(empty($_GET["sdate"]))) { $sdate = $_GET["sdate"]; } else { $sdate = date("Y-m-d"); }
+	if(!(empty($_GET["sdate"])) && preg_match("/^\d{4}-(0\d|1[0-2])-(0\d|1\d|2\d|3[01])$/s", $_GET["sdate"])) { $sdate = $_GET["sdate"]; } else { $sdate = date("Y-m-d"); }
 
 function last_records($rcount, $connection) {
 		global $datax;

--- a/typo_w-temp.php
+++ b/typo_w-temp.php
@@ -8,7 +8,7 @@ date_default_timezone_set("Europe/Berlin");
 	if(!(empty($_GET["rec_count"]))) { $rec_count = $_GET["rec_count"]; } else { $rec_count = 10; }
 	if(!(empty($_GET["avg_hours"]))) { $avg_hours = $_GET["avg_hours"]; } else { $avg_hours = 1; }
 
-	if(!(empty($_GET["sdate"]))) { $sdate = $_GET["sdate"]; } else { $sdate = date("Y-m-d"); }
+	if(!(empty($_GET["sdate"])) && preg_match("/^\d{4}-(0\d|1[0-2])-(0\d|1\d|2\d|3[01])$/s", $_GET["sdate"])) { $sdate = $_GET["sdate"]; } else { $sdate = date("Y-m-d"); }
 
 
 

--- a/wetterseite.php
+++ b/wetterseite.php
@@ -69,7 +69,7 @@ if (!(empty($_GET["avg_hours"]))) {
 } else {
     $avg_hours = 2;
 }
-if (!(empty($_GET["sdate"]))) {
+if (!(empty($_GET["sdate"])) && preg_match("/^\d{4}-(0\d|1[0-2])-(0\d|1\d|2\d|3[01])$/s", $_GET["sdate"])) {
     $sdate = $_GET["sdate"];
 } else {
     $sdate = date("Y-m-d");


### PR DESCRIPTION
Der GET-Parameter `sdate` wird ohne Überprüfung direkt in das MySQL-Query übernommen.
Das eröffnet Möglichkeiten von [SQL-Injections](https://www.w3schools.com/sql/sql_injection.asp). Deshalb sollte `$_GET[..]` vorher überprüft werden.
Im Pull-Request unten wird die Variable über eine RegEx geprüft und bei bedarf durch das aktuelle Datum ersetzt.