### PR TITLE
Add horizontal lines to the wind direction

### DIFF
--- a/typo_w-direction.php
+++ b/typo_w-direction.php
@@ -86,7 +86,12 @@ $graph->xaxis->SetLabelAngle(90);
 // Create the line
 $p1 = new ScatterPlot($datay,$datax);
 
+// Add horizontal lines to display the allowed window
+$west_line = new PlotLine(HORIZONTAL, 22.5*11.5, 'lightgreen', 2*22.5);
+$northost_line = new PlotLine(HORIZONTAL, 22.5*2, 'lightgreen', 22.5);
 
+$graph->Add($west_line);
+$graph->Add($northost_line);
 
 //$p1 = new LinePlot($datay,$datax);
 //$p1->SetColor("#1FE55C");


### PR DESCRIPTION
Ich habe zum Plot der Windrichtung zwei horizontale Linien hinzugefügt, um die erlaubten Windrichtung anzuzeigen.
Sollte ungefähr so aussehen:

![image](https://user-images.githubusercontent.com/1271243/105053634-77a46980-5a71-11eb-8a57-76406cddedb5.png)

Ich finde es ganz praktisch das so anzuzeigen.